### PR TITLE
Remove exclude argument

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,4 +21,3 @@ github_username:  jekyll
 markdown: kramdown
 source: src
 destination: public
-exclude: ['node_modules', 'webpack']


### PR DESCRIPTION
You do not need the `exclude` parameter since `source` is pointing to `src` directory.
`['node_modules', 'webpack']` directories are not in `src` so jekyll won't include them in the build.