### PR TITLE
Change babel to babel-loader for new dependency requirements.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
       {
         test: /\.jsx?$/,
         exclude: /(node_modules)/,
-        loader: 'babel', // 'babel-loader' is also a legal name to reference
+        loader: 'babel-loader',
         query: {
           presets: ['react', 'es2015']
         }


### PR DESCRIPTION
Previously running `webpack` would result in 

"BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
                 You need to specify 'babel-loader' instead of 'babel'."

Resolved this by specifying correct plugin